### PR TITLE
depreciated code is updated.BR1-Issue 6

### DIFF
--- a/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/webanno-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -1050,7 +1050,6 @@ public class AeroRemoteApiController
         if (aState == null) {
             return null;
         }
-
         switch (aState) {
         case "NEW":
             return SourceDocumentState.NEW;


### PR DESCRIPTION
The issue is refered to Issue 6 in BR2 list on Trello. 

The issue was regarding the depreciation of the code. I tried to investigate the issue and found that the ANNOTATION_FINISHED is used in more than one functions. To refactor or remove it we have to make many changes in other class from where this State parameter is coming. I found it in ProjectState Enum and SourceDocumentState etc. The methods which are using these enum and functions are been called by other classes. As it required modification in many other classes so I did not changed them and added supress warning for it.